### PR TITLE
Add results command

### DIFF
--- a/src/main/java/com/checkmarx/util/CheckmarxUtilRunner.java
+++ b/src/main/java/com/checkmarx/util/CheckmarxUtilRunner.java
@@ -1,6 +1,7 @@
 package com.checkmarx.util;
 
 import com.checkmarx.util.cmd.ProjectCommand;
+import com.checkmarx.util.cmd.ResultsCommand;
 import com.checkmarx.util.cmd.RoleCommand;
 import com.checkmarx.util.cmd.TeamCommand;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import java.util.concurrent.Callable;
 public class CheckmarxUtilRunner implements Callable<Integer>, CommandLineRunner, ExitCodeGenerator {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(CheckmarxUtilRunner.class);
     private final ProjectCommand projectCommand;
+    private final ResultsCommand reportCommand;
     private final RoleCommand roleCommand;
     private final TeamCommand teamCommand;
     private int exitCode = 0;
@@ -26,8 +28,10 @@ public class CheckmarxUtilRunner implements Callable<Integer>, CommandLineRunner
     @Spec
     private CommandSpec spec;
 
-    public CheckmarxUtilRunner(ProjectCommand projectCommand, RoleCommand roleCommand, TeamCommand teamCommand) {
+    public CheckmarxUtilRunner(ProjectCommand projectCommand, ResultsCommand reportCommand, RoleCommand roleCommand,
+                               TeamCommand teamCommand) {
 	this.projectCommand = projectCommand;
+    this.reportCommand = reportCommand;
 	this.roleCommand = roleCommand;
 	this.teamCommand = teamCommand;
     }
@@ -42,10 +46,11 @@ public class CheckmarxUtilRunner implements Callable<Integer>, CommandLineRunner
 		.toArray(String[]::new);
 
         exitCode = new CommandLine(this)
-        	.addSubcommand(projectCommand)
-        	.addSubcommand(roleCommand)
-        	.addSubcommand(teamCommand)
-        	.execute(args);
+            .addSubcommand(projectCommand)
+            .addSubcommand(reportCommand)
+            .addSubcommand(roleCommand)
+            .addSubcommand(teamCommand)
+            .execute(args);
     }
 
     @Override

--- a/src/main/java/com/checkmarx/util/cmd/ResultsCommand.java
+++ b/src/main/java/com/checkmarx/util/cmd/ResultsCommand.java
@@ -1,0 +1,123 @@
+package com.checkmarx.util.cmd;
+
+import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.exception.CheckmarxException;
+import com.checkmarx.sdk.service.CxService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+/**
+ * Command for report based operations within Checkmarx
+ */
+@Component
+@Command(name = "results")
+public class ResultsCommand {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(ResultsCommand.class);
+    private final CxService cxService;
+    private final CxProperties cxProperties;
+
+    public enum OutputFormat
+    {
+        JSON
+    }
+
+    @Spec
+    private CommandSpec spec;
+    /**
+     * ResultsCommand Constructor for results operations against Checkmarx
+     * @param cxService the SDK client
+     * @param cxProperties the SDK configuration
+     */
+    public ResultsCommand(CxService cxService, CxProperties cxProperties) {
+        this.cxService = cxService;
+        this.cxProperties = cxProperties;
+    }
+
+    /**
+     * Dummy implementation of the call method to implement the Callable
+     * interface.
+     *
+     * @return CommandLine.ExitCode.USAGE
+     * @throws Exception if an underlying method throws an exception
+     */
+    public Integer call() throws Exception {
+        log.info("Calling results command");
+
+        CommandLine.usage(spec, System.err);
+        return CommandLine.ExitCode.USAGE;
+    }
+
+
+    /**
+     * Retrieve a report
+     * @param reportId the report identifier
+     * @throws CheckmarxException if the SDK throws an exception
+     */
+    @Command(name = "get", description = "Get results")
+    private void getResults(
+            @Option(names = {"-f", "--format"}, description = "The output format") OutputFormat outputFormat,
+            @Option(names = {"-o", "--output-pathname"}, description = "The output pathname") String outputPathname,
+            @Option(names = {"-p", "--project"}, description = "The project name") String projectName,
+            @Option(names = {"-r", "--report-id"}, description = "The report identifier") Integer reportId,
+            @Option(names = {"-s", "--scan-id"}, description = "The scan identifier") Integer scanId
+    ) throws CheckmarxException {
+        log.info("Calling results get command");
+        log.debug("getReport: outputFormat: {}, projectName: {}, reportId: {}, scanId: {}",
+                outputFormat, projectName, reportId, scanId);
+
+        if (outputFormat == null) {
+            outputFormat = OutputFormat.JSON;
+        }
+
+        if (projectName == null && reportId == null && scanId == null) {
+            log.error("Either the project or the report or the scan must be specified");
+            return;
+        }
+
+        Writer writer;
+        if (outputPathname != null) {
+            File outputFile = new File(outputPathname);
+            try {
+                writer = new FileWriter(outputFile);
+            } catch (IOException ioe) {
+                log.error("Error opening {} for writing: {}", outputPathname, ioe.getMessage(), ioe);
+                return;
+            }
+        } else {
+            writer = new OutputStreamWriter(System.out);
+        }
+        ScanResults scanResults = cxService.getReportContent(reportId, null);
+        log.debug("scanResults: {}", scanResults);
+        switch (outputFormat) {
+            case JSON:
+                printJsonResults(scanResults, writer);
+                break;
+        }
+    }
+
+    private void printJsonResults(ScanResults scanResults, Writer writer) {
+        log.debug("printJsonResults");
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            mapper.writeValue(writer, scanResults);
+        } catch (IOException ioe) {
+            log.error("Error writing JSON results: {}", ioe.getMessage(), ioe);
+        }
+    }
+}


### PR DESCRIPTION
This command, at present, only retrieves results and only if given a report identifier. Similarly, the only output format supported so far is JSON.