### PR TITLE
Revert upgrade to Spring Boot 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.0.4'
+	id 'org.springframework.boot' version '2.7.10'
 	id 'java'
 }
 


### PR DESCRIPTION
Spring Boot 3 requires Java 17 and we do not want to force this on our customers at this time.